### PR TITLE
Added/fixed links to EYA cards, remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-gradepointpigeon.cf

--- a/index.html
+++ b/index.html
@@ -44,8 +44,11 @@
             <a href="https://tinyurl.com/gppeyacards2020" class="button">
                 EYA Encouragement 2020
             </a>
-            <a href="tinyurl.com/2021gppcards" class="button">
+            <a href="https://tinyurl.com/2021gppcards" class="button">
                 EYA Encouragement 2021
+            </a>
+            <a href="https://tinyurl.com/2022gppeya" class="button">
+                EYA Encouragement 2022
             </a>
             <a href="https://tinyurl.com/GPPStickers" class="button">
                 Whatsapp/Telegram stickers 2019


### PR DESCRIPTION
Hello! Creating this pull request to make the following changes to the site:

- Added link 2022 EYA Cards
- Fixed broken link to 2021 EYA Card
- Remove CNAME temporarily* because ~~the domain expired~~ and the site currently doesn't resolve anywhere

*by that I mean ~_a Year_